### PR TITLE
algorithms: avoid panic on non-AlgorithmSigner RSA signer

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -210,11 +210,13 @@ func (r *rsaAlgorithm) Sign(rand io.Reader, p crypto.PrivateKey, sig []byte) ([]
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			sshsig, err = r.sshSigner.(ssh.AlgorithmSigner).SignWithAlgorithm(rand, sig, ssh.SigAlgoRSASHA2256)
+		} else if as, ok := r.sshSigner.(ssh.AlgorithmSigner); ok {
+			sshsig, err = as.SignWithAlgorithm(rand, sig, ssh.SigAlgoRSASHA2256)
 			if err != nil {
 				return nil, err
 			}
+		} else {
+			return nil, errors.New("signer does not implement ssh.AlgorithmSigner")
 		}
 
 		return sshsig.Blob, nil


### PR DESCRIPTION
## Summary

- `rsaAlgorithm.Sign()` unconditionally type-asserted `sshSigner` to `ssh.AlgorithmSigner`, causing a runtime panic when the signer does not implement that interface
- Replace the unsafe assertion with an `ok`-pattern check and return an error instead of panicking

Fixes #2 